### PR TITLE
Mostly fixes for bulk-upload tests

### DIFF
--- a/workshops/migrations/0003_auto_20150227_1245.py
+++ b/workshops/migrations/0003_auto_20150227_1245.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workshops', '0002_auto_20150219_1305'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='task',
+            unique_together=set([('event', 'person', 'role')]),
+        ),
+    ]

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -327,6 +327,9 @@ class Task(models.Model):
     person     = models.ForeignKey(Person)
     role       = models.ForeignKey(Role)
 
+    class Meta:
+        unique_together = ("event", "person", "role")
+
     def __str__(self):
         return '{0}/{1}={2}'.format(self.event, self.person, self.role)
 

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -150,6 +150,8 @@ class Person(AbstractBaseUser, PermissionsMixin):
     def save(self, *args, **kwargs):
         # save empty string as NULL to the database - otherwise there are
         # issues with UNIQUE constraint failing
+        self.middle = self.middle or None
+        self.family = self.family or ''
         self.email = self.email or None
         super().save(*args, **kwargs)
 

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -151,7 +151,6 @@ class Person(AbstractBaseUser, PermissionsMixin):
         # save empty string as NULL to the database - otherwise there are
         # issues with UNIQUE constraint failing
         self.middle = self.middle or None
-        self.family = self.family or ''
         self.email = self.email or None
         super().save(*args, **kwargs)
 

--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -121,9 +121,9 @@ class VerifyUploadPersonTask(CSVBulkUploadTestBase):
         # make sure 'errors' wasn't set
         self.assertIsNone(good_data[0]['errors'])
 
-    def test_verify_event_dne(self):
+    def test_verify_event_doesnt_exist(self):
         bad_data = self.make_data()
-        bad_data[0]['event'] = 'dne'
+        bad_data[0]['event'] = 'no-such-event'
         has_errors = verify_upload_person_task(bad_data)
         self.assertTrue(has_errors)
 
@@ -131,7 +131,7 @@ class VerifyUploadPersonTask(CSVBulkUploadTestBase):
         self.assertTrue(len(errors) == 1)
         self.assertTrue('Event with slug' in errors[0])
 
-    def test_verify_role_dne(self):
+    def test_verify_role_doesnt_exist(self):
         bad_data = self.make_data()
         bad_data[0]['role'] = 'foobar'
 
@@ -165,13 +165,16 @@ class VerifyUploadPersonTask(CSVBulkUploadTestBase):
                         " don't match" in errors[0])
 
     def test_verify_existing_user_has_workshop_role_provided(self):
-        bad_data = [dict(), ]
-        bad_data[0]['email'] = 'harry@hogwarts.edu'
-        bad_data[0]['personal'] = 'Harry'
-        bad_data[0]['middle'] = None
-        bad_data[0]['family'] = 'Potter'
-        bad_data[0]['event'] = ''
-        bad_data[0]['role'] = ''
+        bad_data = [
+            {
+                'email': 'harry@hogwarts.edu',
+                'personal': 'Harry',
+                'middle': None,
+                'family': 'Potter',
+                'event': '',
+                'role': '',
+            }
+        ]
         has_errors = verify_upload_person_task(bad_data)
         self.assertTrue(has_errors)
         errors = bad_data[0]['errors']

--- a/workshops/test/test_util.py
+++ b/workshops/test/test_util.py
@@ -305,3 +305,9 @@ Harry,,Potter,harry@hogwarts.edu,foobar,Instructor
                                              event__slug="foobar"))
         self.assertEqual(tasks_pre, tasks_post)
         self.assertEqual(rv.status_code, 400)
+
+        # we need to decode rv.content, because it's bytes, not str
+        _, params = cgi.parse_header(rv['content-type'])
+        charset = params['charset']
+        content = rv.content.decode(charset)
+        self.assertIn('already has role', content)

--- a/workshops/util.py
+++ b/workshops/util.py
@@ -118,7 +118,6 @@ def verify_upload_person_task(data):
             # but we should check if, in case the email matches, family and
             # personal names match, too
 
-            person_exists = False
             try:
                 person = Person.objects.get(email__iexact=email)
 
@@ -138,22 +137,21 @@ def verify_upload_person_task(data):
                             family, person.family)
                 )
 
-            else:
-                person_exists = True
+        if person:
+            if not any([event, role]):
+                errors.append("User exists but no event and role to assign"
+                              " the user to was provided")
 
-        if person_exists and not any([event, role]):
-            errors.append("User exists but no event and role to assign the"
-                          " user to was provided")
-        else:
-            # check for duplicate Task
-            try:
-                Task.objects.get(event__slug=event, role__name=role,
-                                 person=person)
-            except Task.DoesNotExist:
-                pass
             else:
-                errors.append("Existing person {2} already has role {0} in "
-                              "event {1}".format(role, event, person))
+                # check for duplicate Task
+                try:
+                    Task.objects.get(event__slug=event, role__name=role,
+                                     person=person)
+                except Task.DoesNotExist:
+                    pass
+                else:
+                    errors.append("Existing person {2} already has role {0}"
+                                  " in event {1}".format(role, event, person))
 
         if (event and not role) or (role and not event):
             errors.append("Must have both or either of event ({0}) and role"

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -300,11 +300,12 @@ def person_bulk_add_confirmation(request):
         data_update = zip(personals, middles, families, emails, events, roles)
         for k, record in enumerate(data_update):
             personal, middle, family, email, event, role = record
+            # "field or None" converts empty strings to None values
             persons_tasks[k] = {
-                'personal': personal,
-                'middle': middle,
-                'family': family,
-                'email': email
+                'personal': personal or None,
+                'middle': middle or None,
+                'family': family or None,
+                'email': email or None
             }
             # when user wants to drop related event they will send empty string
             # so we should unconditionally accept new value for event even if
@@ -350,7 +351,7 @@ def person_bulk_add_confirmation(request):
                            'persons_tasks': persons_tasks}
                 return render(request,
                               'workshops/person_bulk_add_results.html',
-                              context)
+                              context, status=400)
 
             else:
                 request.session['bulk-add-people'] = None


### PR DESCRIPTION
Hi,

another set of fixes.

* visual fixes (like `dne` → `doesnt_exist`)
* 2 new tests

The last test, `test_upload_existing_user_existing_task`, currently fails because we apparently allow duplicate tasks.

@gvwilson and @wking: is this behavior expected? If so, I'll revert my latest commit. Otherwise we have a bug here.