### PR TITLE
Fix: empty personal/family names representation

### DIFF
--- a/workshops/templates/workshops/person_bulk_add_results.html
+++ b/workshops/templates/workshops/person_bulk_add_results.html
@@ -28,19 +28,19 @@
         {% with i=forloop.counter0 %}
             <td class="editable">
                 <span>{{ entry.personal|default:"&mdash;" }}</span>
-                <input type="text" name="personal" value="{{ entry.personal }}" class="hidden">
+                <input type="text" name="personal" value="{{ entry.personal|default:"" }}" class="hidden">
             </td>
             <td class="editable">
                 <span>{{ entry.middle|default:"&mdash;" }}</span>
-                <input type="text" name="middle" value="{{ entry.middle }}" class="hidden">
+                <input type="text" name="middle" value="{{ entry.middle|default:"" }}" class="hidden">
             </td>
             <td class="editable">
                 <span>{{ entry.family|default:"&mdash;" }}</span>
-                <input type="text" name="family" value="{{ entry.family }}" class="hidden">
+                <input type="text" name="family" value="{{ entry.family|default:"" }}" class="hidden">
             </td>
             <td class="editable">
                 <span>{{ entry.email|default:"&mdash;" }}</span>
-                <input type="text" name="email" value="{{ entry.email }}" class="hidden">
+                <input type="text" name="email" value="{{ entry.email|default:"" }}" class="hidden">
             </td>
             <td class="editable">
                 <span>{{ entry.event|default:"&mdash;" }}</span>

--- a/workshops/views.py
+++ b/workshops/views.py
@@ -302,9 +302,9 @@ def person_bulk_add_confirmation(request):
             personal, middle, family, email, event, role = record
             # "field or None" converts empty strings to None values
             persons_tasks[k] = {
-                'personal': personal or None,
+                'personal': personal,
                 'middle': middle or None,
-                'family': family or None,
+                'family': family,
                 'email': email or None
             }
             # when user wants to drop related event they will send empty string


### PR DESCRIPTION
This fixes an error that caused hidden <input> elements to contain
`value="None"` instead of `value=""`.

Additionally, this commit changes the way we handle incoming form data.
In our models, `Person` has fields `personal`, `family` that are not
nullable.  Therefore we should not default to `None` values for these
fields, because it screws up `util.create_username`.