### PR TITLE
Fix skill→lesson migration, instructor search tests

### DIFF
--- a/workshops/migrations/0011_auto_20150612_0803.py
+++ b/workshops/migrations/0011_auto_20150612_0803.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from functools import partial
 
+from django.contrib.contenttypes.models import ContentType
 from django.db import models, migrations
+
+
+def remove_old_contentype(content_type, apps, schema_editor):
+    """If we change model name, we need to remove its ContentType entry."""
+    ContentType.objects.filter(app_label='workshops', model=content_type) \
+                       .delete()
 
 
 class Migration(migrations.Migration):
@@ -20,4 +28,5 @@ class Migration(migrations.Migration):
             old_name='skill',
             new_name='lesson',
         ),
+        migrations.RunPython(partial(remove_old_contentype, 'skill')),
     ]

--- a/workshops/migrations/0012_auto_20150612_0807.py
+++ b/workshops/migrations/0012_auto_20150612_0807.py
@@ -25,24 +25,26 @@ def add_new_lesson_names(apps, schema_editor):
     Lesson = apps.get_model('workshops', 'Lesson')
     for (old_name, new_names) in TRANSLATE_NAMES.items():
         for name in new_names:
-            lesson = Lesson.objects.create(name=name)
-            lesson.save()
+            Lesson.objects.create(name=name)
 
 
 def fix_duplicate_names(apps, schema_editor):
     '''Fix references to lessons with case sensitivity in names.'''
     Lesson = apps.get_model('workshops', 'Lesson')
     Qualification = apps.get_model('workshops', 'Qualification')
-    right_lesson = Lesson.objects.get(name='Matlab')
-    wrong_lesson = Lesson.objects.get(name='MATLAB')
-    for q in Qualification.objects.filter(lesson=wrong_lesson):
-        q.lesson = right_lesson
-        q.save()
+    try:
+        right_lesson = Lesson.objects.get(name='Matlab')
+        wrong_lesson = Lesson.objects.get(name='MATLAB')
+        Qualification.objects.filter(lesson=wrong_lesson) \
+                             .update(lesson=right_lesson)
+    except Lesson.DoesNotExist:
+        pass
+
 
 def replace_qualifications(apps, schema_editor):
     '''Add qualification entries with new lesson names and delete old ones.'''
-    Qualification = apps.get_model('workshops', 'Qualification')
     Lesson = apps.get_model('workshops', 'Lesson')
+    Qualification = apps.get_model('workshops', 'Qualification')
     for q in Qualification.objects.all():
         old_name = q.lesson.name
         new_names = TRANSLATE_NAMES[old_name]
@@ -58,11 +60,9 @@ def remove_old_skill_names(apps, schema_editor):
     Lesson = apps.get_model('workshops', 'Lesson')
     for (old_name, new_names) in TRANSLATE_NAMES.items():
         if old_name:
-            lesson = Lesson.objects.get(name=old_name)
-            lesson.delete()
+            Lesson.objects.filter(name=old_name).delete()
     for old_name in EXTRA_LEGACY_NAMES:
-        lesson = Lesson.objects.get(name=old_name)
-        lesson.delete()
+        Lesson.objects.filter(name=old_name).delete()
 
 
 class Migration(migrations.Migration):

--- a/workshops/test/test_instructors.py
+++ b/workshops/test/test_instructors.py
@@ -63,7 +63,7 @@ class TestLocateInstructors(TestBase):
     def test_match_instructors_on_one_skill(self):
         response = self.client.post(reverse('instructors'),
                                     {'airport' : self.airport_50_100.id,
-                                     'Git' : 'on',
+                                     'swc/git' : 'on',
                                      'wanted' : 1000})
         assert response.status_code == 200
         content = response.content.decode('utf-8')
@@ -74,8 +74,8 @@ class TestLocateInstructors(TestBase):
     def test_match_instructors_on_two_skills(self):
         response = self.client.post(reverse('instructors'),
                                     {'airport' : self.airport_50_100.id,
-                                     'Git' : 'on',
-                                     'SQL' : 'on',
+                                     'swc/git' : 'on',
+                                     'dc/sql' : 'on',
                                      'wanted' : 1000})
         assert response.status_code == 200
         content = response.content.decode('utf-8')


### PR DESCRIPTION
Migration fixes:
* `.filter().delete()` instead of `o = .get(); o.delete()` for
  performance and less errors
* try-except for migrating MATLAB→Matlab
* `objects.create()` instead of `L=objects.create(); L.save()`

Test fixes:
* send correct form input name to `self.client.post(url, data)`,
  'swc/git' and 'dc/sql' instead of 'Git' and 'SQL'.